### PR TITLE
Downgrade the Android Gradle plugin to the most recent stable version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'si.dlabs:aws-java-sdk-s3:1.9.35'
-    compile 'com.android.tools.build:gradle:1.4.0-beta1'
+    compile 'com.android.tools.build:gradle:1.3.1'
     compile 'com.github.blazsolar.gradle:gradle-hipchat-plugin:0.2.0'
     compile 'org.ajoberstar:grgit:1.1.0'
     compile 'com.squareup.okhttp:okhttp:2.0.0'


### PR DESCRIPTION
Use version 1.3.1, which currently is the most recent officially released
stable version according to

https://sites.google.com/a/android.com/tools/tech-docs/new-build-system

Otherwise, for projects that apply the soter plugin and that are on an
older version of the Android Gradle plugin than version 1.4.0-beta1,
Gradle will use the more recent Android Gradle version, which might have
unwanted side effects for the projects using soter.