### PR TITLE
Fix support for test projects

### DIFF
--- a/src/main/groovy/si/dlabs/gradle/manager/TaskManager.groovy
+++ b/src/main/groovy/si/dlabs/gradle/manager/TaskManager.groovy
@@ -66,12 +66,10 @@ class TaskManager {
     }
 
     private def getVariants(Project project) {
-        if (project.plugins.hasPlugin('com.android.application')) {
+        if (project.plugins.hasPlugin('com.android.application') || project.plugins.hasPlugin('com.android.test')) {
             return project.android.applicationVariants
         } else if (project.plugins.hasPlugin('com.android.library')) {
             return project.android.libraryVariants
-        } else if (project.plugins.hasPlugin('com.android.test')) {
-            return project.android.testVariants
         }
         return Collections.<BaseVariant>emptySet();
     }


### PR DESCRIPTION
In Gradle plugin 2.2, test variants are part of each application and
library project, and test applications are pure application projects.