### PR TITLE
Still prefer testVariants for test apps, if present

### DIFF
--- a/src/main/groovy/si/dlabs/gradle/manager/TaskManager.groovy
+++ b/src/main/groovy/si/dlabs/gradle/manager/TaskManager.groovy
@@ -66,10 +66,16 @@ class TaskManager {
     }
 
     private def getVariants(Project project) {
-        if (project.plugins.hasPlugin('com.android.application') || project.plugins.hasPlugin('com.android.test')) {
+        if (project.plugins.hasPlugin('com.android.application')) {
             return project.android.applicationVariants
         } else if (project.plugins.hasPlugin('com.android.library')) {
             return project.android.libraryVariants
+        } else if (project.plugins.hasPlugin('com.android.test')) {
+            if (project.android.hasProperty('testVariants')) {
+                return project.android.testVariants
+            } else {
+                return project.android.applicationVariants
+            }
         }
         return Collections.<BaseVariant>emptySet();
     }


### PR DESCRIPTION
This maintains compatibility with older versions of the Android Gradle
plugin.
